### PR TITLE
Make Saving Terrain Easier with Hotkeys and More

### DIFF
--- a/addons/zylann.hterrain/tools/plugin.gd
+++ b/addons/zylann.hterrain/tools/plugin.gd
@@ -343,9 +343,7 @@ func _menu_item_selected(id):
 		MENU_CHANNEL_PACKER:
 			_channel_packer.popup_centered_minsize()
 		MENU_SAVE:
-			var data = _node.get_data()
-			if data != null:
-				data.save_data_async()
+			_terrain_save()
 		MENU_LOAD:
 			var data = _node.get_data()
 			if data != null:
@@ -516,4 +514,16 @@ func _terrain_progress_notified(info):
 		_progress_window.show_progress(info.message, info.progress)
 		# TODO Have builtin modal progress bar
 
+# Save when using save hotkey in editor
+func queue_save_layout():
+	_terrain_save()
 
+# Save when closing project and prompted to save
+func save_external_data():
+	_terrain_save()
+
+func _terrain_save():
+	if _node != null:
+		var data = _node.get_data()
+		if data != null:
+			data.save_data_async()


### PR DESCRIPTION
Hi. When I was using this editor, I was frequently using Ctrl+S to save my terrain. But whenever I saved my terrain, it didn't show up "in-game". Weird bug, huh?

As it turns out, I was using it wrong™. It seems that you have to *manually* save your edited terrain by clicking HeightMap -> Save in the 3D Editor.

Anyhow, this PR fixes that. It lets you save the terrain with the Save hotkey (Ctrl+S) as well as the "Do you want to save your project?" dialog when you exit the Godot editor.